### PR TITLE
feat : reject promises with error like object

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -32,6 +32,7 @@ paths.files = [
   'xhr-transformers.js',
   'jsonp-request-message.js',
   'http-request-message.js',
+  'error-http-request-message.js',
   'request-builder.js',
   'http-client.js'
 ].map(function(file){

--- a/src/error-http-response-message.js
+++ b/src/error-http-response-message.js
@@ -1,0 +1,34 @@
+import { HttpResponseMessage } from './http-response-message';
+
+/**
+* Represents an error like object response message from an HTTP or JSONP request.
+*/
+export class ErrorHttpResponseMessage extends HttpResponseMessage {
+
+  /**
+  * Error like name
+  */
+  name: string;
+
+  /**
+  * Error like message
+  */
+  message: string;
+
+  /**
+   * Instanciate a new error response message
+   * ErrorHttpResponseMessage instanceof Error is false we add two members name and message to have an error like object
+   * @param responseMessage response message
+   */
+  constructor(responseMessage: HttpResponseMessage) {
+    super(responseMessage.requestMessage, {
+      response: responseMessage.response,
+      status: responseMessage.statusCode,
+      statusText: responseMessage.statusText
+    }, responseMessage.responseType);
+    //error like properties : name and message
+    this.name = responseMessage.responseType;
+    this.message = `Error: ${responseMessage.statusCode} Status: ${responseMessage.statusText}`;
+  }
+
+}

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -1,11 +1,11 @@
 /*eslint no-unused-vars:0*/
-import {DOM} from 'aurelia-pal';
-import {RequestMessage} from './request-message';
-import {RequestBuilder} from './request-builder';
-import {HttpRequestMessage, createHttpRequestMessageProcessor} from './http-request-message';
-import {HttpResponseMessage} from './http-response-message';
-import {JSONPRequestMessage, createJSONPRequestMessageProcessor} from './jsonp-request-message';
-import {RequestMessageProcessor} from './request-message-processor';
+import { DOM } from 'aurelia-pal';
+import { RequestMessage } from './request-message';
+import { RequestBuilder } from './request-builder';
+import { HttpRequestMessage, createHttpRequestMessageProcessor } from './http-request-message';
+import { HttpResponseMessage } from './http-response-message';
+import { JSONPRequestMessage, createJSONPRequestMessageProcessor } from './jsonp-request-message';
+import { RequestMessageProcessor } from './request-message-processor';
 
 function trackRequestStart(client: HttpClient, processor: RequestMessageProcessor) {
   client.pendingRequests.push(processor);
@@ -28,6 +28,12 @@ function trackRequestEnd(client: HttpClient, processor: RequestMessageProcessor)
 * The main HTTP client object.
 */
 export class HttpClient {
+
+  /**
+  * Return true is promises are rejected with an error like object. Default false
+  */
+  rejectPromiseWithErrorObject: boolean;
+
   /**
   * Indicates whether or not the client is in the process of requesting resources.
   */
@@ -42,6 +48,7 @@ export class HttpClient {
     this.requestProcessorFactories.set(HttpRequestMessage, createHttpRequestMessageProcessor);
     this.requestProcessorFactories.set(JSONPRequestMessage, createJSONPRequestMessageProcessor);
     this.pendingRequests = [];
+    this.rejectPromiseWithErrorObject = false;
   }
 
   /**

--- a/test/http-response-message.spec.js
+++ b/test/http-response-message.spec.js
@@ -70,8 +70,8 @@ describe("HttpResponseMessage", () => {
 
     it("will use the mimeType as the responseType if there is no alias for it in the mimeTypes map", () => {
       runContentTypeExpectations([
-        {contentType:"text/foo", mimeType:"text/foo", responseType:"text/foo", type:"foo"},
-        {contentType:"text/foo; charset=utf-8", mimeType:"text/foo", responseType:"text/foo", type:"foo"}
+        {contentType:"text/foo", mimeType:"text/foo", type:"foo"},
+        {contentType:"text/foo; charset=utf-8", mimeType:"text/foo", type:"foo"}
       ]);
     });
 

--- a/test/request-message-processor.spec.js
+++ b/test/request-message-processor.spec.js
@@ -1,8 +1,9 @@
 import './setup';
-import {RequestMessageProcessor} from '../src/request-message-processor';
-import {HttpResponseMessage} from '../src/http-response-message';
-import {RequestMessage} from '../src/request-message';
-import {PLATFORM} from 'aurelia-pal';
+import { RequestMessageProcessor } from '../src/request-message-processor';
+import { HttpResponseMessage } from '../src/http-response-message';
+import { ErrorHttpResponseMessage } from '../src/error-http-response-message';
+import { RequestMessage } from '../src/request-message';
+import { PLATFORM } from 'aurelia-pal';
 
 describe("Request message processor", () => {
   it("constructor() correctly setup the xhrType and the xhrTransformers", () => {
@@ -79,7 +80,7 @@ describe("Request message processor", () => {
       reqProcessor.xhrTransformers.push(transformSpy);
       reqProcessor.xhrTransformers.push(transformSpy);
       reqProcessor.process(client, message).then(() => {
-        expect(transformSpy).toHaveBeenCalledWith(client, reqProcessor, message,  reqProcessor.xhr);
+        expect(transformSpy).toHaveBeenCalledWith(client, reqProcessor, message, reqProcessor.xhr);
         expect(transformSpy.calls.count()).toBe(2);
         done();
       });
@@ -107,73 +108,110 @@ describe("Request message processor", () => {
       reqProcessor.xhr.fakeResponse(200, "status test", responseObj)
     });
 
-    it("will reject if the onload response has failed", (done) => {
-      let responseObj = {};
+    //test boilerplate
+    let itHelper: (testMsg: string, rejectPromiseWithErrorObjectOption?: boolean) => (testMsg: string, done: () => void) => void;
+    //end  
 
-      reqProcessor.process(client, message)
-        .then((response) => expect(false).toBeTruthy("This should have failed"))
-        .catch((response) => {
-          expect(response).toEqual(jasmine.any(HttpResponseMessage));
-          expect(response.requestMessage).toBe(message);
-          expect(response.statusCode).toBe(401);
-          expect(response.response).toBe(responseObj);
-          expect(response.responseType).toBe("test");
-          expect(response.statusText).toBe("status test");
-          expect(response.reviver).toBe(message.reviver);
-        })
-        .then(done);
+    itHelper = (testMsg: string, rejectPromiseWithErrorObjectOption?: boolean) => {
+      it(testMsg, (done) => {
+        let responseObj = {};
+        let clientCpy = Object.assign({}, client, { rejectPromiseWithErrorObject: rejectPromiseWithErrorObjectOption });
+        reqProcessor.process(clientCpy, message)
+          .then((response) => expect(false).toBeTruthy("This should have failed"))
+          .catch((response) => {
+            expect(response).toEqual(jasmine.any(HttpResponseMessage));
+            if (rejectPromiseWithErrorObjectOption) {
+              expect(response).toEqual(jasmine.any(ErrorHttpResponseMessage));
+            }
+            expect(response.requestMessage).toBe(message);
+            expect(response.statusCode).toBe(401);
+            expect(response.response).toBe(responseObj);
+            expect(response.responseType).toBe("test");
+            expect(response.statusText).toBe("status test");
+            expect(response.reviver).toBe(message.reviver);
+          })
+          .then(done);
 
-      reqProcessor.xhr.fakeResponse(401, "status test", responseObj);
-    });
+        reqProcessor.xhr.fakeResponse(401, "status test", responseObj);
+      });
+    };
+    itHelper("will reject if the onload response has failed");
+    itHelper("will reject if the onload response has failed with rejectPromiseWithErrorObject option", true);
 
-    it("will reject if the ontimeout was called", (done) => {
-      let errorResponse = {};
-      reqProcessor.process(client, message)
-        .then((response) => expect(false).toBeTruthy("This should have failed"))
-        .catch((response) => {
-          expect(response).toEqual(jasmine.any(HttpResponseMessage));
-          expect(response.requestMessage).toBe(message);
-          expect(response.response).toBe(errorResponse);
-          expect(response.responseType).toBe("timeout");
-        })
-        .then(done);
+    itHelper = (testMsg: string, rejectPromiseWithErrorObjectOption?: boolean) => {
+      it(testMsg, (done) => {
 
-      let xhr = reqProcessor.xhr;
-      xhr.ontimeout(errorResponse);
-    });
+        let errorResponse = {};
+        let clientCpy = Object.assign({}, client, { rejectPromiseWithErrorObject: rejectPromiseWithErrorObjectOption });
+        reqProcessor.process(clientCpy, message)
+          .then((response) => expect(false).toBeTruthy("This should have failed"))
+          .catch((response) => {
+            expect(response).toEqual(jasmine.any(HttpResponseMessage));
+            if (rejectPromiseWithErrorObjectOption) {
+              expect(response).toEqual(jasmine.any(ErrorHttpResponseMessage));
+            }
+            expect(response.requestMessage).toBe(message);
+            expect(response.response).toBe(errorResponse);
+            expect(response.responseType).toBe("timeout");
+          })
+          .then(done);
 
-    it("will reject if the onerror was called", (done) => {
-      let errorResponse = {};
-      reqProcessor.process(client, message)
-        .then((response) => expect(false).toBeTruthy("This should have failed"))
-        .catch((response) => {
-          expect(response).toEqual(jasmine.any(HttpResponseMessage));
-          expect(response.requestMessage).toBe(message);
-          expect(response.response).toBe(errorResponse);
-          expect(response.responseType).toBe("error");
-        })
-        .then(done);
+        let xhr = reqProcessor.xhr;
+        xhr.ontimeout(errorResponse);
+      });
+    };
+    itHelper("will reject if the ontimeout was called");
+    itHelper("will reject if the ontimeout was called with rejectPromiseWithErrorObject option", true);
 
-      let xhr = reqProcessor.xhr;
-      xhr.onerror(errorResponse);
-    });
+    itHelper = (testMsg: string, rejectPromiseWithErrorObjectOption?: boolean) => {
+      it(testMsg, (done) => {
 
-    it("will reject if the onabort was called", (done) => {
-      let errorResponse = {};
-      reqProcessor.process(client, message)
-        .then((response) => expect(false).toBeTruthy("This should have failed"))
-        .catch((response) => {
-          expect(response).toEqual(jasmine.any(HttpResponseMessage));
-          expect(response.requestMessage).toBe(message);
-          expect(response.response).toBe(errorResponse);
-          expect(response.responseType).toBe("abort");
-        })
-        .then(done);
+        let errorResponse = {};
+        let clientCpy = Object.assign({}, client, { rejectPromiseWithErrorObject: rejectPromiseWithErrorObjectOption });
+        reqProcessor.process(clientCpy, message)
+          .then((response) => expect(false).toBeTruthy("This should have failed"))
+          .catch((response) => {
+            expect(response).toEqual(jasmine.any(HttpResponseMessage));
+            if (rejectPromiseWithErrorObjectOption) {
+              expect(response).toEqual(jasmine.any(ErrorHttpResponseMessage));
+            }
+            expect(response.requestMessage).toBe(message);
+            expect(response.response).toBe(errorResponse);
+            expect(response.responseType).toBe("error");
+          })
+          .then(done);
 
-      let xhr = reqProcessor.xhr;
-      xhr.status = 200;
-      xhr.onabort(errorResponse);
-    });
+        let xhr = reqProcessor.xhr;
+        xhr.onerror(errorResponse);
+      });
+    };
+    itHelper("will reject if the onerror was called");
+    itHelper("will reject if the onerror was called with rejectPromiseWithErrorObject option", true);
+
+    itHelper = (testMsg: string, rejectPromiseWithErrorObjectOption?: boolean) => {
+      it(testMsg, (done) => {
+        let errorResponse = {};
+        let clientCpy = Object.assign({}, client, { rejectPromiseWithErrorObject: rejectPromiseWithErrorObjectOption });
+        reqProcessor.process(clientCpy, message)
+          .then((response) => expect(false).toBeTruthy("This should have failed"))
+          .catch((response) => {
+            expect(response).toEqual(jasmine.any(HttpResponseMessage));
+            if (rejectPromiseWithErrorObjectOption) {
+              expect(response).toEqual(jasmine.any(ErrorHttpResponseMessage));
+            }
+            expect(response.requestMessage).toBe(message);
+            expect(response.response).toBe(errorResponse);
+            expect(response.responseType).toBe("abort");
+          })
+          .then(done);
+
+        let xhr = reqProcessor.xhr;
+        xhr.status = 200;
+        xhr.onabort(errorResponse);
+      });
+    };
+    itHelper("will reject if the onabort was called");
+    itHelper("will reject if the onabort was called with rejectPromiseWithErrorObject option", true);
 
     it('applies xhr transformers after calling request interceptors', (done) => {
       class RequestInterceptor {
@@ -191,7 +229,7 @@ describe("Request message processor", () => {
 
       message.interceptors = [interceptor]
       reqProcessor.xhrTransformers.push(mockTransformer);
-      reqProcessor.process(client, message).then((response) => { done() } );
+      reqProcessor.process(client, message).then((response) => { done() });
       reqProcessor.xhr.fakeResponse();
     });
   });


### PR DESCRIPTION
It is a best practice to reject a promise with an Error object.
Bluebird promise raise a warning in this case : [http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error](url) because http-client promise   use a `HttpResponseMessage` in rejection handler
I add  `ErrorHttpResponseMessage` inherits `HttpResponseMessage` and add `name` and `message`  string attributes then bluebird considers this object as an error  : [https://github.com/petkaantonov/bluebird/blob/master/src/util.js#L240-L246](url)
I also add `rejectPromiseWithErrorObject: boolean;` property default `false` to change the default behavior.
